### PR TITLE
New method to define keyboards (Closes #7)

### DIFF
--- a/src/parser/parserClasses.py
+++ b/src/parser/parserClasses.py
@@ -1,4 +1,5 @@
 from remapData import keyCodes
+import subprocess
 
 BLANK = -1
 
@@ -80,6 +81,14 @@ class keyboardPathAction(failAction):
         o = ["KeyboardPath",self.path]
         return [' '.join(str(e) for e in o)]
 
+class keyboardNameAction(failAction):
+    def __init__(self,name):
+        self.name = name
+
+    def output(self):
+        o = ["KeyboardPath",kbName2Path(self.name)]
+        return [' '.join(str(e) for e in o)]
+
 class newLayerAction(failAction):
     def __init__(self,key):
         self.keyCode = getKeyCode(key)
@@ -90,6 +99,14 @@ class newLayerAction(failAction):
             return [' '.join(str(e) for e in o)]
         else:
             return ["FAIL"]
+
+def kbName2Path(kbName):
+    command = 'sed -n \'/"'+kbName+'"/,/^$/p\' /proc/bus/input/devices | grep "H:" | grep -o "event\\w*"'
+
+    commandOut = subprocess.getoutput(command)
+    eventName = commandOut.strip()
+
+    return "/dev/input/"+eventName
 
 def isKey(token):
     code = getKeyCode(token)
@@ -205,6 +222,9 @@ def tokenToAction(tokens,hotkey):
 
     if trigger.upper() == "KEYBOARDPATH":
         action = keyboardPathAction(command)
+
+    if trigger.upper() == "KEYBOARDNAME":
+        action = keyboardNameAction(command)
 
     elif trigger.upper() == "NEWLAYER":
         action = newLayerAction(command)

--- a/src/parser/test.py
+++ b/src/parser/test.py
@@ -64,6 +64,18 @@ class testParser(unittest.TestCase):
 
         self.assertEqual(parsedData,parserClasses.parse(data))
 
+        data = [
+        "KeyboardName -> DavRack Atreus50",
+        ]
+
+         
+        parsedData =[
+        "NewLayer 0",
+        "KeyboardPath /dev/input/event3",
+        ]
+
+        self.assertEqual(parsedData,parserClasses.parse(data))
+
     def test_newLayer(self):
         data = [
         "NewLayer->CapsLock"


### PR DESCRIPTION
This pull request implements
```
KeyboardName -> Keyboard name
```
Which gets the keyboard path at run time from /proc/bus/input/devices

For example. the keyboard i want to use with skr is "DavRack Atreus50"
```
I: Bus=0003 Vendor=feed Product=0000 Version=0111
N: Name="DavRack Atreus50"
P: Phys=usb-0000:00:14.0-5/input0
S: Sysfs=/devices/pci0000:00/0000:00:14.0/usb2/2-5/2-5:1.0/0003:FEED:0000.0001/input/input3
U: Uniq=0
H: Handlers=sysrq kbd event3 leds
B: PROP=0
B: EV=120013
B: KEY=1000000000007 ff9f207ac14057ff febeffdfffefffff fffffffffffffffe
B: MSC=10
B: LED=1f

I: Bus=0003 Vendor=feed Product=0000 Version=0111
N: Name="DavRack Atreus50 Mouse"
P: Phys=usb-0000:00:14.0-5/input1
S: Sysfs=/devices/pci0000:00/0000:00:14.0/usb2/2-5/2-5:1.1/0003:FEED:0000.0002/input/input4
U: Uniq=0
H: Handlers=event4 mouse0
B: PROP=0
B: EV=17
B: KEY=1f0000 0 0 0 0
B: REL=1943
B: MSC=10

I: Bus=0003 Vendor=feed Product=0000 Version=0111
N: Name="DavRack Atreus50 System Control"
P: Phys=usb-0000:00:14.0-5/input1
S: Sysfs=/devices/pci0000:00/0000:00:14.0/usb2/2-5/2-5:1.1/0003:FEED:0000.0002/input/input5
U: Uniq=0
H: Handlers=kbd event5
B: PROP=0
B: EV=1b
B: KEY=40000001000000 1200000000 0 800000000 40000010cc00 10168000000000 0
B: ABS=10000000000
B: MSC=10
```
So the skr config file will look something like this
```
KeyboardName -> DavRack Atreus50
.
.
.
```
And skr will find the /dev/input path. in this case /dev/input/event3
KeyboardPath will remain the default option.
